### PR TITLE
add elasticlunr script to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,6 +424,7 @@ index.search("micro", {
 
         <script src="assets/bootstrap/js/jquery-1.11.3.min.js"></script>
         <script src="assets/bootstrap/js/bootstrap.min.js"></script>
+        <script src="elasticlunr.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The home page instructs you to paste some elasticlunr code into the console, but a reference to the script is missing from the page.  