### PR TITLE
Allow for a 0 boost, don't search fields with 0 boost

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -56,6 +56,14 @@
   *   bool: "OR"
   * }
   * 
+  * setting the boost to 0 ignores the field (this will only search the title):
+  * {
+  *   fields:{
+  *     title: {boost: 1},
+  *     body: {boost: 0}
+  *   }
+  * }
+  *
   * then, user could search with configuration to do query-time boosting.
   * idx.search('oracle database', {fields: {title: {boost: 2}, body: {boost: 1}}});
   * 
@@ -130,7 +138,7 @@ elasticlunr.Configuration.prototype.buildUserConfig = function (config, fields) 
         }
 
         this.config[field] = {
-          boost: field_config.boost || 1,
+          boost: (field_config.boost || field_config.boost === 0) ? field_config.boost : 1,
           bool: field_config.bool || global_bool,
           expand: field_expand
         };

--- a/lib/index.js
+++ b/lib/index.js
@@ -371,8 +371,14 @@ elasticlunr.Index.prototype.search = function (query, userConfig) {
 elasticlunr.Index.prototype.fieldSearch = function (queryTokens, fieldName, config) {
   var booleanType = config[fieldName].bool;
   var expand = config[fieldName].expand;
+  var boost = config[fieldName].boost;
   var scores = null;
   var docTokens = {};
+
+  // Do nothing if the boost is 0
+  if (boost === 0) {
+    return;
+  }
 
   queryTokens.forEach(function (token) {
     var tokens = [token];

--- a/test/configuration_test.js
+++ b/test/configuration_test.js
@@ -292,3 +292,24 @@ test('construct with user config, global expand config overwrite by local config
   var config = new elasticlunr.Configuration(userConfig, fields);
   deepEqual(config.get(), target);
 });
+
+test("construct with user config, boost of 0 shouldn't be overwritten", function () {
+  var fields = ['title', 'body'],
+      userConfig = '{"fields": {"title": {"boost": 0},"body": {"boost": 2}}}';
+
+  var target = {
+    title: {
+      boost: 0,
+      bool: "OR",
+      expand: false
+    },
+    body: {
+      boost: 2,
+      bool: "OR",
+      expand: false
+    }
+  };
+
+  var config = new elasticlunr.Configuration(userConfig, fields);
+  deepEqual(config.get(), target);
+});

--- a/test/search_test.js
+++ b/test/search_test.js
@@ -70,3 +70,10 @@ test('search boosts exact matches', function () {
   equal(results.length, 2);
   equal(results[0].ref, 'd');
 });
+
+test('search skips on 0 boost fields', function () {
+  var results = this.idx.search('plant', {fields: {title: {boost: 1}, body: {boost: 0}}});
+
+  equal(results.length, 1);
+  equal(results[0].ref, 'b');
+});


### PR DESCRIPTION
This change makes it possible to dynamically search specific fields, making any search this drives more powerful.

An example use case would be elasticlunr behind a search box which allowed you to search for **just** tags on each document. Previously you could set the boost really high for the tag field but it would still show documents without that tag. This change means that we can search and show **only** articles that have the tag that was searched for.

## Changes

Setup:
```javascript
var idx = new elasticlunr.Index;
idx.addField('body');
idx.addField('title');
idx.addDoc({
  id: 'a',
  title: 'Plumb waters green plant ',
  body: 'Professor Plumb has a green plant in his study',
  wordCount: 9
});
idx.addDoc({
  id: 'b',
  title: 'Scarlett helps Professor',
  body: 'Miss Scarlett watered Professor Plumbs green plant while he was away from his office last week.',
  wordCount: 16
});

var config = {
  fields: {
    title: {boost: 1},
    body: {boost: 0}
  }
}
```

What used to happen:
```javascript
idx.search('plant', config);
# [{"ref":"a","score":0.6981782972972785},{"ref":"b","score":0.1486337229729589}]
# Includes both articles as the boost of 0 is set back to 1 behind the scenes
```

What happens now:
```javascript
idx.search('plant', config);
# [{"ref":"a","score":0.5}]
# Only include the article that has 'plant' in the title, as the body section of each article is never searched
```