### PR TITLE
Include the ‘doc’ in search results, if it exists in the DocumentStore.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -352,8 +352,13 @@ elasticlunr.Index.prototype.search = function (query, userConfig) {
   }
 
   var results = [];
+  var result;
   for (var docRef in queryResults) {
-    results.push({ref: docRef, score: queryResults[docRef]});
+    result = {ref: docRef, score: queryResults[docRef]};
+    if (this.documentStore.hasDoc(docRef)) {
+      result.doc = this.documentStore.getDoc(docRef);
+    }
+    results.push(result);
   }
 
   results.sort(function (a, b) { return b.score - a.score; });


### PR DESCRIPTION
Hi @weixsong,

This pull request includes the `doc` in search results, if it exists in the `DocumentStore`. This is often useful if one wants to be able to see the original document used for indexing. 

``` javascript
[{
    "ref": 1,
    "score": 0.5376053707962494,
    "doc": {title: "The Moon is a Harsh Mistress", id: 1}
},
{
    "ref": 2,
    "score": 0.5237481076838757,
    "doc": {title: "The Wealth of Nations", id: 2}
}]
```

Otherwise one has to keep reference to the docs and pull them back up via the `ref` value in the search results.

This PR is useful to myself, and hopefully others, as I modify my objects into indexable docs prior to index. Then want to get the docs back with the search results without having to create a separate lookup hash of indexed docs.

Many thanks for the great library! Cheers.
