### PR TITLE
Remove sentence about features above download links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,11 +125,10 @@ index.search("Oracle database profit", {
                             <div>
                                 <i class="fa fa-download" style="font-size: 2.0em;"></i>
                                 <h2 style="display:inline;">Download</h2>
-                                <p style="margin-top: 10px">Elasticlunr.js is developed based on lunr.js, but more flexible than lunr.js. The main featues are as followings:</p>
                             </div>
                         </div>
 
-                        <ul style="padding-left: 20px;">
+                        <ul style="padding-left: 20px; padding-top: 10px;">
                             <li><a href="./elasticlunr.js" target="_blank">elasticlunr.js</a> - uncompressed</li>
                             <li><a href="./elasticlunr.min.js" target="_blank">elasticlunr.min.js</a> - minified</li>
                         </ul>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ index.search("Oracle database profit", {
                             <div style="margin-top: 20px; overflow:hidden;">
                                 <i class="fa fa-code box-icon" style="font-size: 2.0em;"></i>
                                 <h2 style="display:inline;">Features</h2>
-                                <p style="margin-top: 10px">Elasticlunr.js is developed based on lunr.js, but more flexible than lunr.js. The main featues are as followings:</p>
+                                <p style="margin-top: 10px">Elasticlunr.js is developed based on lunr.js, but more flexible than lunr.js. The main features are as followings:</p>
                             </div>
                         </div>
                         <ul style="padding-left: 20px;">


### PR DESCRIPTION
Hi!

Firstly - thanks for the very cool project.

This small PR removes "Elasticlunr.js is developed based on lunr.js, but more flexible than lunr.js. The main featues are as followings" just above the download links, while maintaining margin above the top bullet point.

I felt like it was probably a copy+paste error from the "Features" section above.
Finally - there's one small typo correction from "featues" to "features".

Thanks again for the work you've put into this.