### PR TITLE
Enabling a more compressed format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -565,13 +565,14 @@ elasticlunr.Index.prototype.coordNorm = function (scores, docTokens, n) {
 /**
  * Returns a representation of the index ready for serialisation.
  *
+ * @param {boolean} [compress=false]
  * @return {Object}
  * @memberOf Index
  */
-elasticlunr.Index.prototype.toJSON = function () {
+elasticlunr.Index.prototype.toJSON = function (compress) {
   var indexJson = {};
   this._fields.forEach(function (field) {
-    indexJson[field] = this.index[field].toJSON();
+    indexJson[field] = this.index[field].toJSON(compress);
   }, this);
 
   return {

--- a/lib/inverted_index.js
+++ b/lib/inverted_index.js
@@ -24,6 +24,48 @@ elasticlunr.InvertedIndex.load = function (serialisedData) {
   var idx = new this;
   idx.root = serialisedData.root;
 
+  // Expand the nodes from the more compressed format
+  var nodeList = [idx.root];
+
+  while (nodeList.length) {
+    var node = nodeList.shift();
+
+    // node.docs can be skipped
+    if (! node.docs) {
+      node.docs = {};
+    }
+
+    // expand node.docs.* from a "tf" value into an object
+    for (var key in node.docs) {
+      if (typeof node.docs[key] !== "object") {
+        node.docs[key] = {
+          tf: node.docs[key]
+        };
+      }
+    }
+
+    // node.df is removed entirely. It exactly matches the number of
+    // documents.
+    node.df = Object.keys(node.docs).length;
+
+    // Keys get compressed when there is only one key in the child and that
+    // key is not the "docs" key.
+    // So {"a":{"b":{"docs":...}}} becomes {"ab":{"docs":...}}
+    for (var key in node) {
+      if (key != "docs" && key != "df") {
+        if (key.length > 1) {
+          var child = {};
+          child[key.substr(1)] = node[key];
+          node[key.charAt(0)] = child;
+          delete node[key];
+          nodeList.push(child);
+        } else {
+          nodeList.push(node[key]);
+        }
+      }
+    }
+  }
+
   return idx;
 };
 
@@ -32,7 +74,7 @@ elasticlunr.InvertedIndex.load = function (serialisedData) {
  * If the token already exist, then update the tokenInfo.
  *
  * tokenInfo format: { ref: 1, tf: 2}
- * tokenInfor should contains the document's ref and the tf(token frequency) of that token in
+ * tokenInfo should contains the document's ref and the tf(token frequency) of that token in
  * the document.
  *
  * By default this function starts at the root of the current inverted index, however
@@ -224,12 +266,41 @@ elasticlunr.InvertedIndex.prototype.expandToken = function (token, memo, root) {
 /**
  * Returns a representation of the inverted index ready for serialisation.
  *
+ * @param {boolean} [compress=false] Set to true to have a more condensed format.
  * @return {Object}
  * @memberOf InvertedIndex
  */
-elasticlunr.InvertedIndex.prototype.toJSON = function () {
+elasticlunr.InvertedIndex.prototype.toJSON = function (compress) {
+  function copyNode(node) {
+    var copy = {};
+    if (Object.keys(node.docs).length) {
+      copy.docs = {};
+      for (key in node.docs) {
+        copy.docs[key] = +node.docs[key].tf.toFixed(8);
+      }
+    }
+    for (var key in node) {
+      if (key !== "docs" && key !== "df") {
+        var child = copyNode(node[key]);
+        var childKeys = Object.keys(child);
+        if (childKeys.length == 1 && childKeys[0] !== "docs") {
+          copy[key + childKeys[0]] = child[childKeys[0]];
+        } else {
+          copy[key] = child;
+        }
+      }
+    }
+    return copy;
+  }
+
+  if (!compress) {
+    return {
+      root: this.root
+    };
+  }
+
   return {
-    root: this.root
+    root: copyNode(this.root)
   };
 };
 


### PR DESCRIPTION
Sample code to exercise the format. It uses `example_index.json` from the demo website.

    elasticlunr = require(".");
    index = elasticlunr.Index.load(require("./example_index.json"));
    uncompressed = JSON.stringify(index.toJSON());
    compressed = JSON.stringify(index.toJSON(true));

    console.log("Uncompressed bytes: " + uncompressed.length);
    // 842369 bytes
    console.log("Compressed bytes: " + compressed.length);
    // 305818 bytes

To help illustrate the changes, here's a sample index with the word "the" for a single document.

    {"docs":{},"df":0,"t":{"docs":{},"df":0,"h":{"docs":{},"df":0,
        "e":{"docs":{"12345":{"tf":1.234567890123456}}}}}}}

A huge portion of the reduction is simply removing empty `docs` properties and calculating `df` upon load. That got the size down to about 400k.

    {"t":{"h":{"e":{"docs":{"12345":{"tf":1.1234567890123456}}}}}}}

Floating point numbers are now trimmed down to 8 digits. It's a loss in precision, but probably not one that will matter much.

    {"t":{"h":{"e":{"docs":{"12345":{"tf":1.12345678}}}}}}}

The `tf` property is now pulled out of the object since it's the only property in that object. This removes a few more bytes.

    {"t":{"h":{"e":{"docs":{"12345":1.12345678}}}}}}}

Finally, indexes are combined when there was only one possible outcome of the indexing.

    {"the":{"docs":{"12345":1.12345678}}}

Each of these brought the size down dramatically. The loading function has been modified to handle either the compressed format or the regular one, and you can safely mix and match either style starting anywhere in the index tree.