### PR TITLE
Only warn of user config parse failure if it was supplied

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -84,12 +84,16 @@ elasticlunr.Configuration = function (config, fields) {
   this.config = {};
 
   var userConfig;
-  try {
-    userConfig = JSON.parse(config);
-    this.buildUserConfig(userConfig, fields);
-  } catch (error) {
-    elasticlunr.utils.warn('user configuration parse failed, will use default configuration');
+  if (config.length === 0) {
     this.buildDefaultConfig(fields);
+  } else {
+    try {
+      userConfig = JSON.parse(config);
+      this.buildUserConfig(userConfig, fields);
+    } catch (error) {
+      elasticlunr.utils.warn('user configuration parse failed, will use default configuration');
+      this.buildDefaultConfig(fields);
+    }
   }
 };
 


### PR DESCRIPTION
The following error would appear if there was no user configuration string given in `.search()`.

![image](https://user-images.githubusercontent.com/859780/47533990-c4de0480-d883-11e8-9fbd-89d61eb509cd.png)

This PR adds an additional check for whether a config string was even given before trying to parse it.

Fixes #67 