### PR TITLE
Add the possibility for a pipeline element to split a token into sub tokens

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * elasticlunr.Pipelines maintain an ordered list of functions to be applied to 
+ * elasticlunr.Pipelines maintain an ordered list of functions to be applied to
  * both documents tokens and query tokens.
  *
  * An instance of elasticlunr.Index will contain a pipeline
@@ -200,22 +200,24 @@ elasticlunr.Pipeline.prototype.remove = function (fn) {
  * @memberOf Pipeline
  */
 elasticlunr.Pipeline.prototype.run = function (tokens) {
-  var out = [],
-      tokenLength = tokens.length,
-      pipelineLength = this._queue.length;
 
-  for (var i = 0; i < tokenLength; i++) {
-    var token = tokens[i];
+  for (var queue_item of this._queue) {
+    tokens = tokens.reduce( (acc, input_token, i) => {
+      let output = queue_item(input_token, i, tokens);
+      if (!Array.isArray(output)) output = [output];
+      for (var out_token of output) {
+        if (out_token !== null && out_token !== void 0) {
+          acc.push(out_token);
+        }
+      }
+      return acc;
+    }, []);
+    for (var i = tokens.length-1; i >= 0; i--) {
+      if (tokens[i] === "") tokens.splice(i, 1);
+    }
+  }
 
-    for (var j = 0; j < pipelineLength; j++) {
-      token = this._queue[j](token, i, tokens);
-      if (token === void 0 || token === null) break;
-    };
-
-    if (token !== void 0 && token !== null) out.push(token);
-  };
-
-  return out;
+  return tokens;
 };
 
 /**
@@ -239,7 +241,7 @@ elasticlunr.Pipeline.prototype.reset = function () {
 /**
  * Returns a representation of the pipeline ready for serialisation.
  * Only serialize pipeline function's name. Not storing function, so when
- * loading the archived JSON index file, corresponding pipeline function is 
+ * loading the archived JSON index file, corresponding pipeline function is
  * added by registered function of elasticlunr.Pipeline.registeredFunctions
  *
  * Logs a warning if the function has not been registered.

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -200,24 +200,26 @@ elasticlunr.Pipeline.prototype.remove = function (fn) {
  * @memberOf Pipeline
  */
 elasticlunr.Pipeline.prototype.run = function (tokens) {
-
-  for (var queue_item of this._queue) {
-    tokens = tokens.reduce( (acc, input_token, i) => {
-      let output = queue_item(input_token, i, tokens);
+  var out = tokens,
+    queue_length = this._queue.length;
+  for (var i = 0; i < queue_length; i++) {
+    var pipeline_output = [];
+    for (var j = 0; j < out.length; j++) {
+      var output = this._queue[i](out[j], j, out);
       if (!Array.isArray(output)) output = [output];
-      for (var out_token of output) {
-        if (out_token !== null && out_token !== void 0) {
-          acc.push(out_token);
+      for (var k = 0; k < output.length; k++) {
+        if (output[k] !== null && output[k] !== void 0) {
+          pipeline_output.push(output[k]);
         }
       }
-      return acc;
-    }, []);
-    for (var i = tokens.length-1; i >= 0; i--) {
-      if (tokens[i] === "") tokens.splice(i, 1);
     }
+    for (var j = pipeline_output.length-1; j >= 0; j--) {
+      if (pipeline_output[j] === "") pipeline_output.splice(j, 1);
+    }
+    out = pipeline_output;
   }
 
-  return tokens;
+  return out;
 };
 
 /**

--- a/test/pipeline_test.js
+++ b/test/pipeline_test.js
@@ -161,6 +161,14 @@ test("run should filter out any undefined values at each stage in the pipeline",
   equal(output.length, 5);
 });
 
+test("run should allow a pipeline step to split a token into multiple tokens", function() {
+  var pipeline = new elasticlunr.Pipeline,
+      splitter = function(t) { return t.split("-"); };
+  pipeline.add(splitter);
+
+  var output = pipeline.run(['t-h-i-s']);
+  deepEqual(output, ['t', 'h', 'i', 's']);
+});
 test('toJSON', function () {
   var pipeline = new elasticlunr.Pipeline,
       fn1 = function () {},


### PR DESCRIPTION
This commit contains changes to allow a pipeline's `run` command to return either an `Array` or a single element, and an additional test to cover the new use case.

Fixes #99