### PR TITLE
Removed clone() method

### DIFF
--- a/lib/document_store.js
+++ b/lib/document_store.js
@@ -3,27 +3,6 @@
  * Copyright (C) @YEAR Wei Song
  */
 /**
- * Cloning object
- *
- * @param {Object} object in JSON format
- * @return {Object} copied object
- */
-
-function clone(obj) {
-  var copy, attr;
-
-  if (obj === null || typeof obj !== 'object') return obj;
-
-  copy = obj.constructor();
-
-  for (attr in obj) {
-    if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
-  }
-
-  return copy;
-}
-
-/**
  * elasticlunr.DocumentStore is a simple key-value document store used for storing
  * sets of tokens for documents stored in index.
  *
@@ -117,7 +96,7 @@ export default function (elasticlunr) {
     if (!this.hasDoc(docRef)) this.length++;
 
     if (this._save === true) {
-      this.docs[docRef] = clone(doc);
+      this.docs[docRef] = JSON.parse(JSON.stringify(doc));
     } else {
       this.docs[docRef] = null;
     }


### PR DESCRIPTION
The way the clone() method worked, by calling Object.constructor(), is causing TypeErrors in recent browsers. As the documentation for the clone() method stated that the input is treated as JSON we can use the JSON.parse(JSON.stringify()) combo to create a deep clone of the document.